### PR TITLE
Fix podcast feed

### DIFF
--- a/themes/flat-zoo/layouts/index.xml
+++ b/themes/flat-zoo/layouts/index.xml
@@ -23,8 +23,8 @@
       <title>{{ title .Title }} - {{ .Params.subtitle }}</title>
       <itunes:author>{{ .Params.author }}</itunes:author>
       <itunes:summary><![CDATA[{{ .Description }}]></itunes:summary>
-      <enclosure url="{{ .Params.embed_url }}" type="audio/x-mp3" />
-      <guid>{{ .Params.embed_url }}</guid>
+      <enclosure url="{{ .Params.embed_uri }}" type="audio/x-mp3" />
+      <guid>{{ .Params.embed_uri }}</guid>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }} </pubDate>
       <itunes:duration></itunes:duration>

--- a/themes/flat-zoo/layouts/partials/head.html
+++ b/themes/flat-zoo/layouts/partials/head.html
@@ -29,6 +29,9 @@
 <!-- Favicons -->
 <link rel="shortcut icon" href="=images/favicon.png">
 
+<!-- Podcast Atom feed -->
+<link rel="alternate" type="application/rss+xml" title="Podcast feed" href="index.xml"/>
+
 
 {{ if isset .Site.Params "GATID" }}
 <script>


### PR DESCRIPTION
I accidentally referenced `embed_url` rather than `embed_uri`, so I've fixed that and added a link in `<head/>` so podcatchers can pick up on the feed automatically (and some browsers).

:cake: 